### PR TITLE
feat: implement API key split - admin keys and project keys

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -12,7 +12,7 @@ Project-scoped. One client per project, goroutine-safe.
 
 ```go
 ts := tripswitch.NewClient("proj_abc123",
-    tripswitch.WithAPIKey("sk_..."),
+    tripswitch.WithAPIKey("eb_pk_..."),
     tripswitch.WithIngestKey("ik_..."),
     tripswitch.WithFailOpen(true),                    // default: true
     tripswitch.WithBaseURL("https://..."),            // optional override

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import (
 func main() {
     // Create client
     ts := tripswitch.NewClient("proj_abc123",
-        tripswitch.WithAPIKey("sk_..."),
+        tripswitch.WithAPIKey("eb_pk_..."),
         tripswitch.WithIngestKey("ik_..."),
     )
     defer ts.Close(context.Background())

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -4,10 +4,16 @@
 // administrative operations for managing projects, breakers, routers,
 // notification channels, and querying events and status.
 //
+// # Authentication
+//
+// The admin client requires an admin API key (prefix: eb_admin_).
+// Admin keys are org-scoped and grant access to all projects within the org.
+// Create admin keys via the Tripswitch dashboard or API.
+//
 // # Quick Start
 //
 //	client := admin.NewClient(
-//	    admin.WithAPIKey("sk_..."),
+//	    admin.WithAPIKey("eb_admin_..."),
 //	)
 //
 //	// Get project details
@@ -80,7 +86,8 @@ func NewClient(opts ...Option) *Client {
 	return c
 }
 
-// WithAPIKey sets the API key for authentication.
+// WithAPIKey sets the admin API key for authentication.
+// Admin keys have the prefix "eb_admin_" and are org-scoped.
 func WithAPIKey(key string) Option {
 	return func(c *Client) {
 		c.apiKey = key

--- a/admin/admin_integration_test.go
+++ b/admin/admin_integration_test.go
@@ -9,7 +9,7 @@ import (
 
 // Integration tests are gated by environment variables.
 // Run with:
-//   TRIPSWITCH_API_KEY=sk_... TRIPSWITCH_PROJECT_ID=proj_... go test -v -run Integration
+//   TRIPSWITCH_API_KEY=eb_admin_... TRIPSWITCH_PROJECT_ID=proj_... go test -v -run Integration
 //
 // Optional:
 //   TRIPSWITCH_BASE_URL=https://api.tripswitch.dev (defaults to production)
@@ -75,27 +75,8 @@ func TestIntegration_ListBreakers(t *testing.T) {
 	}
 }
 
-func TestIntegration_GetStatus(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
-
-	client := NewClient(
-		WithAPIKey(apiKey),
-		WithBaseURL(baseURL),
-	)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	status, err := client.GetStatus(ctx, projectID)
-	if err != nil {
-		t.Fatalf("GetStatus failed: %v", err)
-	}
-
-	t.Logf("Status: %d open, %d closed",
-		status.OpenCount,
-		status.ClosedCount,
-	)
-}
+// TestIntegration_GetStatus removed - GetStatus moved to runtime client (tripswitch.Client)
+// because it requires a project API key (eb_pk_), not an admin key.
 
 func TestIntegration_BreakerCRUD(t *testing.T) {
 	apiKey, projectID, baseURL := skipIfNoEnv(t)

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestNewClient(t *testing.T) {
 	client := NewClient(
-		WithAPIKey("sk_test"),
+		WithAPIKey("eb_admin_test"),
 		WithBaseURL("https://custom.api.dev"),
 	)
 
-	if client.apiKey != "sk_test" {
-		t.Errorf("expected apiKey 'sk_test', got %q", client.apiKey)
+	if client.apiKey != "eb_admin_test" {
+		t.Errorf("expected apiKey 'eb_admin_test', got %q", client.apiKey)
 	}
 	if client.baseURL != "https://custom.api.dev" {
 		t.Errorf("expected baseURL 'https://custom.api.dev', got %q", client.baseURL)
@@ -32,7 +32,7 @@ func TestGetProject(t *testing.T) {
 		if r.URL.Path != "/v1/projects/proj_123" {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
-		if auth := r.Header.Get("Authorization"); auth != "Bearer sk_test" {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer eb_admin_test" {
 			t.Errorf("unexpected auth header: %s", auth)
 		}
 
@@ -45,7 +45,7 @@ func TestGetProject(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(
-		WithAPIKey("sk_test"),
+		WithAPIKey("eb_admin_test"),
 		WithBaseURL(server.URL),
 	)
 
@@ -336,7 +336,7 @@ func TestRequestOptions(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(WithBaseURL(server.URL), WithAPIKey("sk_test"))
+	client := NewClient(WithBaseURL(server.URL), WithAPIKey("eb_admin_test"))
 
 	_, err := client.GetProject(context.Background(), "proj_123",
 		WithRequestID("trace_123"),
@@ -506,30 +506,8 @@ func TestListEvents(t *testing.T) {
 	}
 }
 
-func TestGetStatus(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(Status{
-			OpenCount:   2,
-			ClosedCount: 8,
-			LastEvalMs:  1234567890,
-		})
-	}))
-	defer server.Close()
-
-	client := NewClient(WithBaseURL(server.URL))
-
-	status, err := client.GetStatus(context.Background(), "proj_123")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if status.ClosedCount != 8 {
-		t.Errorf("expected 8 closed breakers, got %d", status.ClosedCount)
-	}
-	if status.OpenCount != 2 {
-		t.Errorf("expected 2 open breakers, got %d", status.OpenCount)
-	}
-}
+// TestGetStatus removed - GetStatus moved to runtime client (tripswitch.Client)
+// See tripswitch_test.go for the new test.
 
 func TestBreakerPager(t *testing.T) {
 	callCount := 0

--- a/admin/events.go
+++ b/admin/events.go
@@ -39,19 +39,9 @@ func (c *Client) ListEvents(ctx context.Context, projectID string, params ListEv
 	return &result, nil
 }
 
-// GetStatus retrieves the project status summary.
-func (c *Client) GetStatus(ctx context.Context, projectID string, opts ...RequestOption) (*Status, error) {
-	var status Status
-	err := c.do(ctx, request{
-		method:  http.MethodGet,
-		path:    "/v1/projects/" + projectID + "/status",
-		options: opts,
-	}, &status)
-	if err != nil {
-		return nil, err
-	}
-	return &status, nil
-}
+// GetStatus is no longer available in the admin client.
+// Use tripswitch.Client.GetStatus() instead, which requires a project API key (eb_pk_).
+// The status endpoint is a runtime read operation and belongs with the runtime client.
 
 // EventPager provides paginated iteration over events.
 type EventPager struct {

--- a/admin/project_keys.go
+++ b/admin/project_keys.go
@@ -1,0 +1,50 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+)
+
+// ListProjectKeys lists all API keys for a project.
+// Requires an admin API key (eb_admin_).
+func (c *Client) ListProjectKeys(ctx context.Context, projectID string, opts ...RequestOption) (*ListProjectKeysResponse, error) {
+	var result ListProjectKeysResponse
+	err := c.do(ctx, request{
+		method:  http.MethodGet,
+		path:    "/v1/projects/" + projectID + "/keys",
+		options: opts,
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// CreateProjectKey creates a new project API key.
+// The returned Key field contains the full API key (eb_pk_...) and is only
+// available on creation. Store it securely as it cannot be retrieved later.
+// Requires an admin API key (eb_admin_).
+func (c *Client) CreateProjectKey(ctx context.Context, projectID string, input CreateProjectKeyInput, opts ...RequestOption) (*CreateProjectKeyResponse, error) {
+	var result CreateProjectKeyResponse
+	err := c.do(ctx, request{
+		method:  http.MethodPost,
+		path:    "/v1/projects/" + projectID + "/keys",
+		body:    input,
+		options: opts,
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteProjectKey revokes a project API key.
+// Once revoked, the key can no longer be used for authentication.
+// Requires an admin API key (eb_admin_).
+func (c *Client) DeleteProjectKey(ctx context.Context, projectID, keyID string, opts ...RequestOption) error {
+	return c.do(ctx, request{
+		method:  http.MethodDelete,
+		path:    "/v1/projects/" + projectID + "/keys/" + keyID,
+		options: opts,
+	}, nil)
+}

--- a/admin/project_keys_test.go
+++ b/admin/project_keys_test.go
@@ -1,0 +1,172 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListProjectKeys(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/projects/proj_123/keys" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer eb_admin_test" {
+			t.Errorf("unexpected auth header: %s", auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ListProjectKeysResponse{
+			Keys: []ProjectKey{
+				{ID: "key_1", Name: "production", KeyPrefix: "eb_pk_abc123"},
+				{ID: "key_2", Name: "staging", KeyPrefix: "eb_pk_def456"},
+			},
+			Count: 2,
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("eb_admin_test"),
+		WithBaseURL(server.URL),
+	)
+
+	result, err := client.ListProjectKeys(context.Background(), "proj_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(result.Keys))
+	}
+	if result.Count != 2 {
+		t.Errorf("expected count 2, got %d", result.Count)
+	}
+	if result.Keys[0].Name != "production" {
+		t.Errorf("expected name 'production', got %q", result.Keys[0].Name)
+	}
+}
+
+func TestCreateProjectKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/projects/proj_123/keys" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var input CreateProjectKeyInput
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			t.Fatalf("failed to decode request body: %v", err)
+		}
+		if input.Name != "my-service-key" {
+			t.Errorf("unexpected name: %s", input.Name)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(CreateProjectKeyResponse{
+			ID:        "key_new",
+			Name:      input.Name,
+			Key:       "eb_pk_full_secret_key_here",
+			KeyPrefix: "eb_pk_full_se",
+			Message:   "Store this key securely - it cannot be retrieved later.",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("eb_admin_test"),
+		WithBaseURL(server.URL),
+	)
+
+	result, err := client.CreateProjectKey(context.Background(), "proj_123", CreateProjectKeyInput{
+		Name: "my-service-key",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID != "key_new" {
+		t.Errorf("expected ID 'key_new', got %q", result.ID)
+	}
+	if result.Key != "eb_pk_full_secret_key_here" {
+		t.Errorf("expected full key, got %q", result.Key)
+	}
+	if result.KeyPrefix != "eb_pk_full_se" {
+		t.Errorf("expected key prefix, got %q", result.KeyPrefix)
+	}
+}
+
+func TestDeleteProjectKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/projects/proj_123/keys/key_456" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("eb_admin_test"),
+		WithBaseURL(server.URL),
+	)
+
+	err := client.DeleteProjectKey(context.Background(), "proj_123", "key_456")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateProjectKey_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Missing or invalid admin API key",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("eb_pk_wrong_key_type"),
+		WithBaseURL(server.URL),
+	)
+
+	_, err := client.CreateProjectKey(context.Background(), "proj_123", CreateProjectKeyInput{
+		Name: "test",
+	})
+	if !IsUnauthorized(err) {
+		t.Errorf("expected unauthorized error, got %v", err)
+	}
+}
+
+func TestCreateProjectKey_Forbidden(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "Project belongs to a different org",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(
+		WithAPIKey("eb_admin_other_org"),
+		WithBaseURL(server.URL),
+	)
+
+	_, err := client.CreateProjectKey(context.Background(), "proj_123", CreateProjectKeyInput{
+		Name: "test",
+	})
+	if !IsForbidden(err) {
+		t.Errorf("expected forbidden error, got %v", err)
+	}
+}

--- a/admin/types.go
+++ b/admin/types.go
@@ -278,9 +278,35 @@ type ListEventsResponse struct {
 	NextCursor *string `json:"next_cursor,omitempty"`
 }
 
-// Status represents the project status summary.
-type Status struct {
-	OpenCount   int   `json:"open_count"`
-	ClosedCount int   `json:"closed_count"`
-	LastEvalMs  int64 `json:"last_eval_ms,omitempty"`
+// ProjectKey represents a project API key (eb_pk_...).
+// Project keys are project-scoped and used for runtime operations
+// like SSE subscriptions and breaker state reads.
+type ProjectKey struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	KeyPrefix  string     `json:"key_prefix"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	InsertedAt time.Time  `json:"inserted_at"`
+}
+
+// ListProjectKeysResponse contains the response from listing project keys.
+type ListProjectKeysResponse struct {
+	Keys  []ProjectKey `json:"keys"`
+	Count int          `json:"count"`
+}
+
+// CreateProjectKeyInput contains fields for creating a project key.
+type CreateProjectKeyInput struct {
+	Name string `json:"name,omitempty"`
+}
+
+// CreateProjectKeyResponse contains the response from creating a project key.
+// The Key field contains the full API key and is only returned on creation.
+// Store it securely as it cannot be retrieved later.
+type CreateProjectKeyResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Key       string `json:"key"`
+	KeyPrefix string `json:"key_prefix"`
+	Message   string `json:"message,omitempty"`
 }

--- a/examples/database/main.go
+++ b/examples/database/main.go
@@ -26,7 +26,7 @@ var db *sql.DB
 func main() {
 	// Create Tripswitch client
 	ts := tripswitch.NewClient("proj_abc123",
-		tripswitch.WithAPIKey("sk_live_..."),
+		tripswitch.WithAPIKey("eb_pk_..."),
 		tripswitch.WithIngestSecret("..."), // 64-char hex string
 	)
 	defer ts.Close(context.Background())

--- a/examples/evaluator/main.go
+++ b/examples/evaluator/main.go
@@ -28,7 +28,7 @@ func (e *HTTPError) Error() string {
 func main() {
 	// Create Tripswitch client
 	ts := tripswitch.NewClient("proj_abc123",
-		tripswitch.WithAPIKey("sk_live_..."),
+		tripswitch.WithAPIKey("eb_pk_..."),
 		tripswitch.WithIngestSecret("..."), // 64-char hex string
 	)
 	defer ts.Close(context.Background())

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -18,7 +18,7 @@ import (
 func main() {
 	// Create Tripswitch client
 	ts := tripswitch.NewClient("proj_abc123",
-		tripswitch.WithAPIKey("sk_live_..."),
+		tripswitch.WithAPIKey("eb_pk_..."),
 		tripswitch.WithIngestSecret("..."), // 64-char hex string
 	)
 	defer ts.Close(context.Background())

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	// Create Tripswitch client with OpenTelemetry trace ID extraction
 	ts := tripswitch.NewClient("proj_abc123",
-		tripswitch.WithAPIKey("sk_live_..."),
+		tripswitch.WithAPIKey("eb_pk_..."),
 		tripswitch.WithIngestKey("ik_live_..."),
 		// Extract trace ID from OpenTelemetry context
 		tripswitch.WithTraceIDExtractor(func(ctx context.Context) string {

--- a/examples/shutdown/main.go
+++ b/examples/shutdown/main.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	// Create Tripswitch client
 	ts := tripswitch.NewClient("proj_abc123",
-		tripswitch.WithAPIKey("sk_live_..."),
+		tripswitch.WithAPIKey("eb_pk_..."),
 		tripswitch.WithIngestSecret("..."), // 64-char hex string
 	)
 

--- a/examples/tags/main.go
+++ b/examples/tags/main.go
@@ -23,7 +23,7 @@ type User struct {
 func main() {
 	// Create Tripswitch client with global tags
 	ts := tripswitch.NewClient("proj_abc123",
-		tripswitch.WithAPIKey("sk_live_..."),
+		tripswitch.WithAPIKey("eb_pk_..."),
 		tripswitch.WithIngestSecret("..."), // 64-char hex string
 		// Global tags applied to ALL samples
 		tripswitch.WithGlobalTags(map[string]string{

--- a/tripswitch_integration_test.go
+++ b/tripswitch_integration_test.go
@@ -10,7 +10,7 @@ import (
 // Integration tests are gated by environment variables.
 // Run with:
 //
-//	TRIPSWITCH_API_KEY=sk_...
+//	TRIPSWITCH_API_KEY=eb_pk_...
 //	TRIPSWITCH_INGEST_SECRET=<64-char-hex>
 //	TRIPSWITCH_PROJECT_ID=proj_...
 //	TRIPSWITCH_BREAKER_NAME=my-breaker
@@ -178,4 +178,28 @@ func TestIntegration_GracefulShutdown(t *testing.T) {
 	}
 
 	t.Log("Graceful shutdown completed")
+}
+
+func TestIntegration_GetStatus(t *testing.T) {
+	cfg := skipIfNoEnv(t)
+
+	client := NewClient(cfg.projectID,
+		WithAPIKey(cfg.apiKey),
+		WithBaseURL(cfg.baseURL),
+	)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		client.Close(ctx)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	status, err := client.GetStatus(ctx)
+	if err != nil {
+		t.Fatalf("GetStatus failed: %v", err)
+	}
+
+	t.Logf("Status: %d open, %d closed", status.OpenCount, status.ClosedCount)
 }


### PR DESCRIPTION
## Summary

Aligns SDK with server-side API key split. Two key types now exist:

- **Admin key** (`eb_admin_`): Org-scoped, for management operations
- **Project key** (`eb_pk_`): Project-scoped, for runtime operations (SSE, state reads)

## Breaking Changes

- Ingest endpoint changed from `/v1/metrics` to `/v1/projects/{project_id}/ingest`
- `x-eb-project-id` header removed (project now in URL path)
- Header casing updated to `X-EB-Timestamp`, `X-EB-Signature`
- `GetStatus` moved from admin client to runtime client (requires project key)

## New Features

- Project key management in admin client:
  - `ListProjectKeys(projectID)`
  - `CreateProjectKey(projectID, input)`
  - `DeleteProjectKey(projectID, keyID)`
- `GetStatus()` method on runtime client

## Changes

| Area | Change |
|------|--------|
| `tripswitch.go` | New ingest endpoint, updated headers, added GetStatus |
| `admin/admin.go` | Documentation for `eb_admin_` keys |
| `admin/project_keys.go` | New file - project key CRUD |
| `admin/types.go` | `ProjectKey`, `CreateProjectKeyInput`, `CreateProjectKeyResponse` |
| `admin/events.go` | Removed GetStatus (moved to runtime client) |
| Examples & docs | Updated to use new key prefixes |

## Test Plan

- [x] All unit tests pass
- [x] New project key tests added and passing
- [x] New GetStatus test added and passing
- [x] Integration tests pass against live server

Closes #18, #19, #20, #21
Related: #24