### PR TITLE
feat: add SDK Contract v0.2 compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Official Go client SDK for [Tripswitch](https://tripswitch.dev) - a circuit brea
 
 > **v0.3.0 Breaking Changes:** This release introduces a two-tier authentication model. API keys are now split into project keys (`eb_pk_`) for runtime SDK usage and admin keys (`eb_admin_`) for management operations. See [Authentication](#authentication) for details.
 
+This SDK conforms to the [Tripswitch SDK Contract v0.2](https://tripswitch.dev/docs/sdk-contract).
+
 ## Features
 
 - **Real-time state sync** via Server-Sent Events (SSE)

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -227,14 +227,14 @@ func (c *Client) do(ctx context.Context, req request, result any) error {
 	// Execute request
 	resp, err := c.httpClient.Do(httpReq)
 	if err != nil {
-		return fmt.Errorf("tripswitch: request failed: %w", err)
+		return fmt.Errorf("%w: %v", ErrTransport, err)
 	}
 	defer resp.Body.Close()
 
 	// Read response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("tripswitch: failed to read response body: %w", err)
+		return fmt.Errorf("%w: failed to read response body: %v", ErrTransport, err)
 	}
 
 	// Check for errors

--- a/tripswitch.go
+++ b/tripswitch.go
@@ -328,6 +328,10 @@ func WithTraceID(traceID string) ExecuteOption {
 	}
 }
 
+// ContractVersion declares the SDK Contract version this implementation conforms to.
+// See https://app.tripswitch.dev/docs/sdk-contract.md
+const ContractVersion = "0.2"
+
 var (
 	// ErrOpen is returned by Execute when the circuit breaker is open.
 	ErrOpen = errors.New("tripswitch: breaker is open")


### PR DESCRIPTION
## Summary

- Add `ErrTransport` and `ErrServerFault` to complete the canonical error taxonomy
- Add `IsTransport()` and `IsServerFault()` helper functions
- Map 5xx HTTP responses to `ErrServerFault` in `APIError.Is()`
- Wrap HTTP client failures with `ErrTransport` for proper error classification
- Add `ContractVersion` constant declaring conformance to SDK Contract v0.2
- Add contract conformance note to README
- Add unit tests for new error types
- Fix `BreakerCRUD` integration test (use unique names, remove `GetBreakerState` call)

## Test plan

- [x] `go test ./...` passes
- [x] Integration tests pass (main SDK + admin)