### PR TITLE
feat: make both breakers and router optional in Execute signature

### DIFF
--- a/examples/database/main.go
+++ b/examples/database/main.go
@@ -45,10 +45,11 @@ func main() {
 	)
 
 	// Look up user - sql.ErrNoRows should NOT trip the breaker
-	user, err := tripswitch.Execute(ts, ctx, routerID, func() (*User, error) {
+	user, err := tripswitch.Execute(ts, ctx, func() (*User, error) {
 		return findUserByID(ctx, 123)
 	},
 		tripswitch.WithBreakers(breakerName),
+		tripswitch.WithRouter(routerID),
 		tripswitch.WithMetric("latency", tripswitch.Latency),
 		tripswitch.WithIgnoreErrors(sql.ErrNoRows),
 	)

--- a/examples/evaluator/main.go
+++ b/examples/evaluator/main.go
@@ -59,10 +59,11 @@ func main() {
 	}
 
 	// Make API call with custom evaluator
-	result, err := tripswitch.Execute(ts, ctx, routerID, func() (string, error) {
+	result, err := tripswitch.Execute(ts, ctx, func() (string, error) {
 		return callPaymentAPI(ctx)
 	},
 		tripswitch.WithBreakers(breakerName),
+		tripswitch.WithRouter(routerID),
 		tripswitch.WithMetric("latency", tripswitch.Latency),
 		tripswitch.WithErrorEvaluator(isServerError),
 	)

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -40,7 +40,7 @@ func main() {
 	client := &http.Client{Timeout: 5 * time.Second}
 
 	// Wrap HTTP call with circuit breaker
-	resp, err := tripswitch.Execute(ts, ctx, routerID, func() (*http.Response, error) {
+	resp, err := tripswitch.Execute(ts, ctx, func() (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.example.com/data", nil)
 		if err != nil {
 			return nil, err
@@ -48,6 +48,7 @@ func main() {
 		return client.Do(req)
 	},
 		tripswitch.WithBreakers(breakerName),
+		tripswitch.WithRouter(routerID),
 		tripswitch.WithMetric("latency", tripswitch.Latency),
 	)
 

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -51,9 +51,12 @@ func main() {
 	defer span.End()
 
 	// Execute with automatic trace ID extraction
-	result, err := tripswitch.Execute(ts, ctx, "inventory-check", func() (bool, error) {
+	result, err := tripswitch.Execute(ts, ctx, func() (bool, error) {
 		return checkInventory(ctx, "SKU-12345")
-	})
+	},
+		tripswitch.WithRouter("inventory-check"),
+		tripswitch.WithMetric("latency", tripswitch.Latency),
+	)
 
 	if err != nil {
 		if tripswitch.IsBreakerError(err) {

--- a/examples/shutdown/main.go
+++ b/examples/shutdown/main.go
@@ -45,11 +45,12 @@ func main() {
 	// Create HTTP server
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/data", func(w http.ResponseWriter, r *http.Request) {
-		result, err := tripswitch.Execute(ts, r.Context(), routerID, func() (string, error) {
+		result, err := tripswitch.Execute(ts, r.Context(), func() (string, error) {
 			// Simulated work
 			return "Hello, World!", nil
 		},
 			tripswitch.WithBreakers(breakerName),
+			tripswitch.WithRouter(routerID),
 			tripswitch.WithMetric("latency", tripswitch.Latency),
 		)
 		if err != nil {

--- a/examples/tags/main.go
+++ b/examples/tags/main.go
@@ -55,10 +55,11 @@ func main() {
 
 	// Execute with per-request tags (merged with global tags)
 	// Per-request tags override global tags on key conflict
-	result, err := tripswitch.Execute(ts, ctx, checkoutRouterID, func() (string, error) {
+	result, err := tripswitch.Execute(ts, ctx, func() (string, error) {
 		return processCheckout(ctx, user)
 	},
 		tripswitch.WithBreakers(checkoutBreaker),
+		tripswitch.WithRouter(checkoutRouterID),
 		tripswitch.WithMetric("latency", tripswitch.Latency),
 		tripswitch.WithTags(map[string]string{
 			"user_tier": user.Tier,
@@ -78,10 +79,11 @@ func main() {
 	fmt.Printf("Checkout complete: %s\n", result)
 
 	// You can also override the trace ID explicitly if needed
-	_, _ = tripswitch.Execute(ts, ctx, paymentRouterID, func() (bool, error) {
+	_, _ = tripswitch.Execute(ts, ctx, func() (bool, error) {
 		return processPayment(ctx)
 	},
 		tripswitch.WithBreakers(paymentBreaker),
+		tripswitch.WithRouter(paymentRouterID),
 		tripswitch.WithMetric("latency", tripswitch.Latency),
 		tripswitch.WithTraceID("custom-trace-id-123"),
 		tripswitch.WithTags(map[string]string{

--- a/tripswitch_integration_test.go
+++ b/tripswitch_integration_test.go
@@ -98,9 +98,9 @@ func TestIntegration_Execute(t *testing.T) {
 	}
 
 	// Execute a simple task using the configured breaker
-	result, err := Execute(client, ctx, cfg.routerID, func() (string, error) {
+	result, err := Execute(client, ctx, func() (string, error) {
 		return "success", nil
-	}, WithBreakers(cfg.breakerName), WithMetric(cfg.metricName, Latency))
+	}, WithBreakers(cfg.breakerName), WithRouter(cfg.routerID), WithMetric(cfg.metricName, Latency))
 
 	// The breaker might be open, closed, or not exist (fail-open)
 	if err != nil && !IsBreakerError(err) {
@@ -163,9 +163,9 @@ func TestIntegration_GracefulShutdown(t *testing.T) {
 
 	// Execute a few tasks to generate samples
 	for i := 0; i < 5; i++ {
-		Execute(client, ctx, cfg.routerID, func() (int, error) {
+		Execute(client, ctx, func() (int, error) {
 			return i, nil
-		}, WithBreakers(cfg.breakerName), WithMetric(cfg.metricName, Latency))
+		}, WithBreakers(cfg.breakerName), WithRouter(cfg.routerID), WithMetric(cfg.metricName, Latency))
 	}
 
 	// Graceful shutdown should flush samples


### PR DESCRIPTION
## Summary

- Remove `routerID` from `Execute` function signature
- Add `WithRouter()` option for sample routing  
- No `WithBreakers` = no gating (pass-through, task always runs)
- No `WithRouter` = no samples emitted
- If `WithMetric` specified but no `WithRouter`, log warning

## New API

```go
// Full usage - gating + metrics
Execute(c, ctx, task,
    WithBreakers("payment-gateway"),
    WithRouter("router-id"),
    WithMetric("latency", Latency),
)

// Gating only, no metrics
Execute(c, ctx, task,
    WithBreakers("payment-gateway"),
)

// Metrics only, no gating (observability without circuit breaking)
Execute(c, ctx, task,
    WithRouter("router-id"),
    WithMetric("latency", Latency),
)
```

## Breaking Change

This changes the `Execute` signature (removes `routerID` parameter). Would be v0.6.0.

## Test plan

- [x] All existing tests updated and passing
- [x] New tests added for: no router = no samples, metrics without router warns, gating-only, metrics-only
- [x] All examples updated and building

Closes #38