### PR TITLE
feat: replace WithMetric with map-based WithMetrics

### DIFF
--- a/examples/database/main.go
+++ b/examples/database/main.go
@@ -50,7 +50,7 @@ func main() {
 	},
 		tripswitch.WithBreakers(breakerName),
 		tripswitch.WithRouter(routerID),
-		tripswitch.WithMetric("latency", tripswitch.Latency),
+		tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 		tripswitch.WithIgnoreErrors(sql.ErrNoRows),
 	)
 

--- a/examples/evaluator/main.go
+++ b/examples/evaluator/main.go
@@ -64,7 +64,7 @@ func main() {
 	},
 		tripswitch.WithBreakers(breakerName),
 		tripswitch.WithRouter(routerID),
-		tripswitch.WithMetric("latency", tripswitch.Latency),
+		tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 		tripswitch.WithErrorEvaluator(isServerError),
 	)
 

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -49,7 +49,7 @@ func main() {
 	},
 		tripswitch.WithBreakers(breakerName),
 		tripswitch.WithRouter(routerID),
-		tripswitch.WithMetric("latency", tripswitch.Latency),
+		tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 	)
 
 	if err != nil {

--- a/examples/otel/main.go
+++ b/examples/otel/main.go
@@ -55,7 +55,7 @@ func main() {
 		return checkInventory(ctx, "SKU-12345")
 	},
 		tripswitch.WithRouter("inventory-check"),
-		tripswitch.WithMetric("latency", tripswitch.Latency),
+		tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 	)
 
 	if err != nil {

--- a/examples/shutdown/main.go
+++ b/examples/shutdown/main.go
@@ -51,7 +51,7 @@ func main() {
 		},
 			tripswitch.WithBreakers(breakerName),
 			tripswitch.WithRouter(routerID),
-			tripswitch.WithMetric("latency", tripswitch.Latency),
+			tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 		)
 		if err != nil {
 			if tripswitch.IsBreakerError(err) {

--- a/examples/tags/main.go
+++ b/examples/tags/main.go
@@ -60,7 +60,7 @@ func main() {
 	},
 		tripswitch.WithBreakers(checkoutBreaker),
 		tripswitch.WithRouter(checkoutRouterID),
-		tripswitch.WithMetric("latency", tripswitch.Latency),
+		tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 		tripswitch.WithTags(map[string]string{
 			"user_tier": user.Tier,
 			"user_id":   user.ID,
@@ -84,7 +84,7 @@ func main() {
 	},
 		tripswitch.WithBreakers(paymentBreaker),
 		tripswitch.WithRouter(paymentRouterID),
-		tripswitch.WithMetric("latency", tripswitch.Latency),
+		tripswitch.WithMetrics(map[string]any{"latency": tripswitch.Latency}),
 		tripswitch.WithTraceID("custom-trace-id-123"),
 		tripswitch.WithTags(map[string]string{
 			"payment_method": "credit_card",

--- a/tripswitch_integration_test.go
+++ b/tripswitch_integration_test.go
@@ -100,7 +100,7 @@ func TestIntegration_Execute(t *testing.T) {
 	// Execute a simple task using the configured breaker
 	result, err := Execute(client, ctx, func() (string, error) {
 		return "success", nil
-	}, WithBreakers(cfg.breakerName), WithRouter(cfg.routerID), WithMetric(cfg.metricName, Latency))
+	}, WithBreakers(cfg.breakerName), WithRouter(cfg.routerID), WithMetrics(map[string]any{cfg.metricName: Latency}))
 
 	// The breaker might be open, closed, or not exist (fail-open)
 	if err != nil && !IsBreakerError(err) {
@@ -165,7 +165,7 @@ func TestIntegration_GracefulShutdown(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		Execute(client, ctx, func() (int, error) {
 			return i, nil
-		}, WithBreakers(cfg.breakerName), WithRouter(cfg.routerID), WithMetric(cfg.metricName, Latency))
+		}, WithBreakers(cfg.breakerName), WithRouter(cfg.routerID), WithMetrics(map[string]any{cfg.metricName: Latency}))
 	}
 
 	// Graceful shutdown should flush samples


### PR DESCRIPTION
## Summary
- Remove `WithMetric(key, value)` in favor of `WithMetrics(map[string]any{...})`
- Update all call sites: tests, integration tests, examples, README
- Empty keys are silently ignored

## Breaking change
`WithMetric` is removed. Replace:
```go
// Before
WithMetric("latency", tripswitch.Latency),
WithMetric("count", 1),

// After
WithMetrics(map[string]any{
    "latency": tripswitch.Latency,
    "count":   1,
}),
```

## Test plan
- [x] All existing tests updated and passing
- [x] Integration tests updated
- [x] All examples updated
- [x] No remaining `WithMetric(` references in codebase
- [x] Full test suite passes

Closes #46