### PR TITLE
feat: add in-memory metadata cache with periodic sync (#54)

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -11,6 +11,9 @@ import (
 // ErrNotModified is returned when the server responds with 304 Not Modified.
 var ErrNotModified = errors.New("tripswitch: not modified")
 
+// ErrUnauthorized is returned when the server responds with 401 or 403.
+var ErrUnauthorized = errors.New("tripswitch: unauthorized")
+
 // BreakerMeta contains a breaker's identity and metadata.
 type BreakerMeta struct {
 	ID       string            `json:"id"`
@@ -62,6 +65,10 @@ func (c *Client) ListBreakersMetadata(ctx context.Context, etag string) ([]Break
 		return nil, etag, ErrNotModified
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, "", ErrUnauthorized
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("tripswitch: unexpected status code: %d", resp.StatusCode)
 	}
@@ -101,6 +108,10 @@ func (c *Client) ListRoutersMetadata(ctx context.Context, etag string) ([]Router
 
 	if resp.StatusCode == http.StatusNotModified {
 		return nil, etag, ErrNotModified
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return nil, "", ErrUnauthorized
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/metadata_cache.go
+++ b/metadata_cache.go
@@ -1,0 +1,120 @@
+package tripswitch
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// startMetadataSync runs the background metadata refresh goroutine.
+// The caller must call c.wg.Add(1) before launching this goroutine.
+func (c *Client) startMetadataSync() {
+	defer c.wg.Done()
+
+	// Initial fetch — best effort; stop if auth fails
+	if c.refreshMetadata(c.ctx) {
+		return
+	}
+
+	ticker := time.NewTicker(c.metaSyncInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			if c.refreshMetadata(c.ctx) {
+				return
+			}
+		}
+	}
+}
+
+// refreshMetadata fetches breaker and router metadata, using ETags for
+// conditional requests. On 304 Not Modified the cache is left unchanged.
+// Returns true if the caller should stop syncing (e.g., on auth failure).
+func (c *Client) refreshMetadata(ctx context.Context) (stop bool) {
+	c.metaMu.RLock()
+	bETag := c.breakersETag
+	rETag := c.routersETag
+	c.metaMu.RUnlock()
+
+	// Fetch breakers metadata with its own timeout
+	bCtx, bCancel := context.WithTimeout(ctx, 10*time.Second)
+	breakers, newBETag, err := c.ListBreakersMetadata(bCtx, bETag)
+	bCancel()
+	if errors.Is(err, ErrUnauthorized) {
+		c.logger.Warn("metadata sync stopping due to auth failure")
+		return true
+	}
+	if err != nil && !errors.Is(err, ErrNotModified) {
+		c.logger.Warn("failed to refresh breakers metadata", "error", err)
+	}
+	if err == nil {
+		c.metaMu.Lock()
+		c.breakersMeta = breakers
+		c.breakersETag = newBETag
+		c.metaMu.Unlock()
+	}
+
+	// Fetch routers metadata with its own timeout
+	rCtx, rCancel := context.WithTimeout(ctx, 10*time.Second)
+	routers, newRETag, err := c.ListRoutersMetadata(rCtx, rETag)
+	rCancel()
+	if errors.Is(err, ErrUnauthorized) {
+		c.logger.Warn("metadata sync stopping due to auth failure")
+		return true
+	}
+	if err != nil && !errors.Is(err, ErrNotModified) {
+		c.logger.Warn("failed to refresh routers metadata", "error", err)
+	}
+	if err == nil {
+		c.metaMu.Lock()
+		c.routersMeta = routers
+		c.routersETag = newRETag
+		c.metaMu.Unlock()
+	}
+
+	return false
+}
+
+// GetBreakersMetadata returns a deep copy of the cached breaker metadata.
+func (c *Client) GetBreakersMetadata() []BreakerMeta {
+	c.metaMu.RLock()
+	defer c.metaMu.RUnlock()
+	if c.breakersMeta == nil {
+		return nil
+	}
+	result := make([]BreakerMeta, len(c.breakersMeta))
+	for i, b := range c.breakersMeta {
+		result[i] = BreakerMeta{ID: b.ID, Name: b.Name}
+		if b.Metadata != nil {
+			result[i].Metadata = make(map[string]string, len(b.Metadata))
+			for k, v := range b.Metadata {
+				result[i].Metadata[k] = v
+			}
+		}
+	}
+	return result
+}
+
+// GetRoutersMetadata returns a deep copy of the cached router metadata.
+func (c *Client) GetRoutersMetadata() []RouterMeta {
+	c.metaMu.RLock()
+	defer c.metaMu.RUnlock()
+	if c.routersMeta == nil {
+		return nil
+	}
+	result := make([]RouterMeta, len(c.routersMeta))
+	for i, r := range c.routersMeta {
+		result[i] = RouterMeta{ID: r.ID, Name: r.Name}
+		if r.Metadata != nil {
+			result[i].Metadata = make(map[string]string, len(r.Metadata))
+			for k, v := range r.Metadata {
+				result[i].Metadata[k] = v
+			}
+		}
+	}
+	return result
+}

--- a/metadata_cache_test.go
+++ b/metadata_cache_test.go
@@ -1,0 +1,345 @@
+package tripswitch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// cacheTestServer creates a test server that handles SSE, breakers metadata,
+// and routers metadata paths. The breakers/routers handlers are caller-provided.
+func cacheTestServer(t *testing.T, breakersHandler, routersHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	breakersPath := "/v1/projects/proj_123/breakers/metadata"
+	routersPath := "/v1/projects/proj_123/routers/metadata"
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case breakersPath:
+			if breakersHandler != nil {
+				breakersHandler(w, r)
+			}
+		case routersPath:
+			if routersHandler != nil {
+				routersHandler(w, r)
+			}
+		default:
+			// SSE endpoint
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				return
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprintf(w, "data: {\"breaker\": \"test\", \"state\": \"closed\", \"allow_rate\": 1.0}\n\n")
+			flusher.Flush()
+			<-r.Context().Done()
+		}
+	}))
+}
+
+func TestMetadataSync_InitialFetch(t *testing.T) {
+	bHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"b1"`)
+		json.NewEncoder(w).Encode(breakersMetadataResponse{
+			Breakers: []BreakerMeta{{ID: "brk_1", Name: "latency"}},
+		})
+	}
+	rHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"r1"`)
+		json.NewEncoder(w).Encode(routersMetadataResponse{
+			Routers: []RouterMeta{{ID: "rtr_1", Name: "main"}},
+		})
+	}
+
+	server := cacheTestServer(t, bHandler, rHandler)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithAPIKey("eb_pk_test"),
+		WithBaseURL(server.URL),
+		WithMetadataSyncInterval(time.Hour), // large interval so only initial fetch runs
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := ts.Ready(ctx); err != nil {
+		t.Fatalf("ready: %v", err)
+	}
+
+	// Give metadata sync goroutine time to complete initial fetch
+	time.Sleep(200 * time.Millisecond)
+
+	breakers := ts.GetBreakersMetadata()
+	if len(breakers) != 1 || breakers[0].ID != "brk_1" {
+		t.Errorf("expected 1 breaker brk_1, got %v", breakers)
+	}
+
+	routers := ts.GetRoutersMetadata()
+	if len(routers) != 1 || routers[0].ID != "rtr_1" {
+		t.Errorf("expected 1 router rtr_1, got %v", routers)
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	ts.Close(closeCtx)
+}
+
+func TestMetadataSync_Refresh(t *testing.T) {
+	var callCount atomic.Int32
+
+	bHandler := func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			w.Header().Set("ETag", `"b1"`)
+			json.NewEncoder(w).Encode(breakersMetadataResponse{
+				Breakers: []BreakerMeta{{ID: "brk_1", Name: "v1"}},
+			})
+		} else {
+			// Subsequent calls should have an If-None-Match header
+			if inm := r.Header.Get("If-None-Match"); inm == "" {
+				t.Errorf("expected If-None-Match header, got empty")
+			}
+			w.Header().Set("ETag", `"b2"`)
+			json.NewEncoder(w).Encode(breakersMetadataResponse{
+				Breakers: []BreakerMeta{{ID: "brk_1", Name: "v2"}},
+			})
+		}
+	}
+	rHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"r1"`)
+		json.NewEncoder(w).Encode(routersMetadataResponse{})
+	}
+
+	server := cacheTestServer(t, bHandler, rHandler)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithAPIKey("eb_pk_test"),
+		WithBaseURL(server.URL),
+		WithMetadataSyncInterval(100*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ts.Ready(ctx)
+
+	// Wait for at least one refresh cycle
+	time.Sleep(400 * time.Millisecond)
+
+	breakers := ts.GetBreakersMetadata()
+	if len(breakers) != 1 || breakers[0].Name != "v2" {
+		t.Errorf("expected updated breaker name v2, got %v", breakers)
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	ts.Close(closeCtx)
+}
+
+func TestMetadataSync_NotModified(t *testing.T) {
+	var bCallCount atomic.Int32
+
+	bHandler := func(w http.ResponseWriter, r *http.Request) {
+		n := bCallCount.Add(1)
+		if n == 1 {
+			w.Header().Set("ETag", `"b1"`)
+			json.NewEncoder(w).Encode(breakersMetadataResponse{
+				Breakers: []BreakerMeta{{ID: "brk_1", Name: "original"}},
+			})
+		} else {
+			w.WriteHeader(http.StatusNotModified)
+		}
+	}
+	rHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"r1"`)
+		json.NewEncoder(w).Encode(routersMetadataResponse{})
+	}
+
+	server := cacheTestServer(t, bHandler, rHandler)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithAPIKey("eb_pk_test"),
+		WithBaseURL(server.URL),
+		WithMetadataSyncInterval(100*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ts.Ready(ctx)
+
+	// Wait for refresh
+	time.Sleep(300 * time.Millisecond)
+
+	breakers := ts.GetBreakersMetadata()
+	if len(breakers) != 1 || breakers[0].Name != "original" {
+		t.Errorf("expected cache unchanged with name 'original', got %v", breakers)
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	ts.Close(closeCtx)
+}
+
+func TestMetadataSync_InitFailure(t *testing.T) {
+	bHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	rHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	server := cacheTestServer(t, bHandler, rHandler)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithAPIKey("eb_pk_test"),
+		WithBaseURL(server.URL),
+		WithMetadataSyncInterval(time.Hour),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ts.Ready(ctx)
+
+	// Give initial fetch time to complete (and fail)
+	time.Sleep(200 * time.Millisecond)
+
+	// Client should still work with empty cache
+	breakers := ts.GetBreakersMetadata()
+	if len(breakers) != 0 {
+		t.Errorf("expected empty breakers cache, got %v", breakers)
+	}
+	routers := ts.GetRoutersMetadata()
+	if len(routers) != 0 {
+		t.Errorf("expected empty routers cache, got %v", routers)
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	ts.Close(closeCtx)
+}
+
+func TestMetadataSync_AuthFailure(t *testing.T) {
+	var callCount atomic.Int32
+
+	bHandler := func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+	rHandler := func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+
+	server := cacheTestServer(t, bHandler, rHandler)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithAPIKey("eb_pk_bad"),
+		WithBaseURL(server.URL),
+		WithMetadataSyncInterval(50*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ts.Ready(ctx)
+
+	// Give initial fetch time to complete and fail
+	time.Sleep(100 * time.Millisecond)
+	countAfterInit := callCount.Load()
+
+	// Wait and verify no more calls (sync should have stopped)
+	time.Sleep(200 * time.Millisecond)
+	countLater := callCount.Load()
+
+	if countLater != countAfterInit {
+		t.Errorf("metadata sync continued after auth failure: %d -> %d", countAfterInit, countLater)
+	}
+
+	// Should have only been 1 call (breakers returns 401, sync stops before routers)
+	if countAfterInit != 1 {
+		t.Errorf("expected 1 call before stopping, got %d", countAfterInit)
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	ts.Close(closeCtx)
+}
+
+func TestGetBreakersMetadata_Empty(t *testing.T) {
+	server := cacheTestServer(t, nil, nil)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
+	)
+
+	// No sync running — cache should be empty
+	breakers := ts.GetBreakersMetadata()
+	if breakers != nil && len(breakers) != 0 {
+		t.Errorf("expected nil/empty breakers, got %v", breakers)
+	}
+	routers := ts.GetRoutersMetadata()
+	if routers != nil && len(routers) != 0 {
+		t.Errorf("expected nil/empty routers, got %v", routers)
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	ts.Close(closeCtx)
+}
+
+func TestMetadataSync_Shutdown(t *testing.T) {
+	var callCount atomic.Int32
+
+	bHandler := func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("ETag", `"b1"`)
+		json.NewEncoder(w).Encode(breakersMetadataResponse{})
+	}
+	rHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"r1"`)
+		json.NewEncoder(w).Encode(routersMetadataResponse{})
+	}
+
+	server := cacheTestServer(t, bHandler, rHandler)
+	defer server.Close()
+
+	ts := NewClient("proj_123",
+		WithAPIKey("eb_pk_test"),
+		WithBaseURL(server.URL),
+		WithMetadataSyncInterval(50*time.Millisecond),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ts.Ready(ctx)
+
+	// Let a few refreshes happen
+	time.Sleep(200 * time.Millisecond)
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer closeCancel()
+	if err := ts.Close(closeCtx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Wait a bit for any in-flight requests to complete, then snapshot
+	time.Sleep(100 * time.Millisecond)
+	countAfterClose := callCount.Load()
+
+	// Verify no more calls happen after shutdown settles
+	time.Sleep(300 * time.Millisecond)
+	countLater := callCount.Load()
+
+	if countLater != countAfterClose {
+		t.Errorf("metadata sync continued after close: %d -> %d", countAfterClose, countLater)
+	}
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -55,6 +55,7 @@ func TestListBreakersMetadata(t *testing.T) {
 	ts := NewClient("proj_123",
 		WithAPIKey("eb_pk_test"),
 		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -98,6 +99,7 @@ func TestListBreakersMetadata_IfNoneMatchHeader(t *testing.T) {
 	ts := NewClient("proj_123",
 		WithAPIKey("eb_pk_test"),
 		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -121,6 +123,7 @@ func TestListBreakersMetadata_NotModified(t *testing.T) {
 	ts := NewClient("proj_123",
 		WithAPIKey("eb_pk_test"),
 		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -160,6 +163,7 @@ func TestListRoutersMetadata(t *testing.T) {
 	ts := NewClient("proj_123",
 		WithAPIKey("eb_pk_test"),
 		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -192,6 +196,7 @@ func TestListRoutersMetadata_NotModified(t *testing.T) {
 	ts := NewClient("proj_123",
 		WithAPIKey("eb_pk_test"),
 		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/tripswitch_test.go
+++ b/tripswitch_test.go
@@ -81,6 +81,7 @@ func TestNewClient(t *testing.T) {
 		WithGlobalTags(tags),
 		WithTraceIDExtractor(extractor),
 		WithOnStateChange(func(name, from, to string) {}),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -117,7 +118,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	// Test default values with mock server
-	tsDefault := NewClient("proj_456", WithBaseURL(server.URL))
+	tsDefault := NewClient("proj_456", WithBaseURL(server.URL), withMetadataSyncDisabled())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -154,7 +155,7 @@ func TestClose(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ts := NewClient("proj_abc", WithBaseURL(server.URL))
+	ts := NewClient("proj_abc", WithBaseURL(server.URL), withMetadataSyncDisabled())
 
 	// Wait for SSE connection to be established before closing
 	// This avoids race condition where Close() is called while SSE is still connecting
@@ -192,7 +193,7 @@ func TestStats(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ts := NewClient("proj_abc", WithBaseURL(server.URL))
+	ts := NewClient("proj_abc", WithBaseURL(server.URL), withMetadataSyncDisabled())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -256,7 +257,7 @@ func TestReady(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client := NewClient("proj_test", WithBaseURL(ts.URL))
+	client := NewClient("proj_test", WithBaseURL(ts.URL), withMetadataSyncDisabled())
 	defer func() {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer closeCancel()
@@ -298,7 +299,7 @@ func newTestClient(t *testing.T, opts ...Option) (*Client, func()) {
 		<-r.Context().Done()
 	}))
 
-	allOpts := append([]Option{WithBaseURL(server.URL)}, opts...)
+	allOpts := append([]Option{WithBaseURL(server.URL), withMetadataSyncDisabled()}, opts...)
 	client := NewClient("proj_test", allOpts...)
 
 	cleanup := func() {
@@ -731,7 +732,7 @@ func TestSendBatch_PayloadFormat(t *testing.T) {
 
 	// Use a valid 64-char hex string for the ingest secret
 	ingestSecret := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	client := NewClient("proj_test", WithBaseURL(server.URL), WithIngestSecret(ingestSecret))
+	client := NewClient("proj_test", WithBaseURL(server.URL), WithIngestSecret(ingestSecret), withMetadataSyncDisabled())
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -837,6 +838,7 @@ func TestGetStatus(t *testing.T) {
 	client := NewClient("proj_123",
 		WithAPIKey("eb_pk_test"),
 		WithBaseURL(server.URL),
+		withMetadataSyncDisabled(),
 	)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## Summary

- Add background goroutine to `Client` that fetches breaker/router metadata on init and refreshes periodically using ETag conditional requests (`ListBreakersMetadata`/`ListRoutersMetadata`)
- Expose `GetBreakersMetadata()` and `GetRoutersMetadata()` public accessors for cached metadata
- Add `WithMetadataSyncInterval` option (default 30s) and graceful degradation on fetch failure (empty cache, warn log)

## Changes

- **`tripswitch.go`** — new struct fields for metadata cache, `WithMetadataSyncInterval` option, goroutine launch in `NewClient` with `wg.Add(1)` before `go` to avoid shutdown race
- **`metadata_cache.go`** (new) — `startMetadataSync`, `refreshMetadata` (with 10s per-request timeout), `GetBreakersMetadata`, `GetRoutersMetadata`
- **`metadata_cache_test.go`** (new) — tests for initial fetch, ETag refresh, 304 Not Modified, init failure, empty cache, shutdown
- **`metadata_test.go`** / **`tripswitch_test.go`** — add `withMetadataSyncDisabled()` to existing test clients to prevent background sync from hitting test servers

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1 -short` (passed twice consecutively)
- [x] Verify metadata cache populates correctly against a live Tripswitch instance