### PR TITLE
feat: add LastSSEEvent, FlushFailures, and CachedBreakers to SDKStats

### DIFF
--- a/tripswitch.go
+++ b/tripswitch.go
@@ -140,7 +140,6 @@ type Client struct {
 	stats struct {
 		// a lock for the stats since they are updated concurrently
 		mu                  sync.RWMutex
-		droppedSamples      uint64
 		bufferSize          int
 		sseConnected        bool
 		sseReconnects       uint64
@@ -230,7 +229,7 @@ type SDKStats struct {
 func (c *Client) Stats() SDKStats {
 	c.stats.mu.RLock()
 	s := SDKStats{
-		DroppedSamples:      c.stats.droppedSamples,
+		DroppedSamples:      atomic.LoadUint64(&c.droppedSamples),
 		BufferSize:          c.stats.bufferSize,
 		SSEConnected:        c.stats.sseConnected,
 		SSEReconnects:       c.stats.sseReconnects,

--- a/tripswitch_test.go
+++ b/tripswitch_test.go
@@ -200,8 +200,8 @@ func TestStats(t *testing.T) {
 		ts.Close(ctx)
 	}()
 
+	atomic.StoreUint64(&ts.droppedSamples, 5)
 	ts.stats.mu.Lock()
-	ts.stats.droppedSamples = 5
 	ts.stats.sseConnected = true
 	ts.stats.mu.Unlock()
 


### PR DESCRIPTION
## Summary

Closes #30

- Add `LastSSEEvent`, `FlushFailures`, and `CachedBreakers` fields to `SDKStats` for better operational observability and TypeScript SDK parity
- Record `lastSSEEvent` timestamp in the SSE handler on each received event
- Increment `flushFailures` counter in `sendBatch` when all retries are exhausted
- Read `CachedBreakers` from `len(breakerStates)` under its own lock in `Stats()`
- Fix pre-existing bug: `DroppedSamples` was always 0 — all writes targeted the atomic `c.droppedSamples` field, but `Stats()` read the never-written `c.stats.droppedSamples`. Removed the dead field and switched to `atomic.LoadUint64`

## Test plan

- [x] `TestStats_LastSSEEvent` — verifies `LastSSEEvent` is non-zero after SSE event received
- [x] `TestStats_FlushFailures` — sends batch to a 500-returning server, verifies counter increments after retry exhaustion
- [x] `TestStats_CachedBreakers` — populates breaker state cache, verifies `CachedBreakers` matches count
- [x] `TestStats` — existing test updated to use `atomic.StoreUint64`, now actually exercises the read path
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Full test suite passes