### PR TITLE
fix: warn on null allow_rate in half_open SSE events

### DIFF
--- a/tripswitch.go
+++ b/tripswitch.go
@@ -770,9 +770,9 @@ func (c *Client) Close(ctx context.Context) error {
 
 // sseBreakerEvent represents the JSON payload of an SSE event for a breaker state change.
 type sseBreakerEvent struct {
-	Breaker   string  `json:"breaker"`
-	State     string  `json:"state"`
-	AllowRate float64 `json:"allow_rate"`
+	Breaker   string   `json:"breaker"`
+	State     string   `json:"state"`
+	AllowRate *float64 `json:"allow_rate"`
 }
 
 // startSSEListener connects to the SSE endpoint, listens for breaker state changes,
@@ -804,7 +804,16 @@ func (c *Client) startSSEListener() {
 			c.logger.Error("failed to unmarshal SSE event", "error", err, "data", string(msg.Data))
 			return
 		}
-		c.updateBreakerState(event.Breaker, event.State, event.AllowRate)
+
+		allowRate := 0.0
+		if event.AllowRate != nil {
+			allowRate = *event.AllowRate
+		} else if event.State == "half_open" {
+			// Only warn for half_open — allow_rate is meaningless for open (always blocked)
+			// and closed (always allowed), so null is harmless for those states.
+			c.logger.Warn("SSE event has null allow_rate for half_open breaker", "breaker", event.Breaker)
+		}
+		c.updateBreakerState(event.Breaker, event.State, allowRate)
 
 		// Mark SSE as connected and record event time
 		c.stats.mu.Lock()

--- a/tripswitch_test.go
+++ b/tripswitch_test.go
@@ -2075,3 +2075,69 @@ func TestGetAllStates(t *testing.T) {
 		t.Errorf("unexpected shipping state: %+v", shipping)
 	}
 }
+
+func TestSSE_NullAllowRate_HalfOpen(t *testing.T) {
+	logger := &mockLogger{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		// Send half_open event with null allow_rate (server bug scenario)
+		fmt.Fprintf(w, "data: {\"breaker\": \"payment-error-rate\", \"state\": \"half_open\", \"allow_rate\": null}\n\n")
+		flusher.Flush()
+
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+			return
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client, err := NewClient(ctx, "proj_test",
+		WithAPIKey("eb_pk_test"),
+		WithBaseURL(server.URL),
+		WithLogger(logger),
+		withMetadataSyncDisabled(),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer closeCancel()
+		client.Close(closeCtx)
+	}()
+
+	// State is guaranteed written before sseReady is closed, so no race here —
+	// NewClient blocks on sseReady when an API key is set.
+	client.breakerStatesMu.RLock()
+	state, ok := client.breakerStates["payment-error-rate"]
+	client.breakerStatesMu.RUnlock()
+
+	if !ok {
+		t.Fatal("expected payment-error-rate in breaker states")
+	}
+	if state.State != "half_open" {
+		t.Errorf("expected state=half_open, got %s", state.State)
+	}
+	// null allow_rate unmarshals to 0.0 — SDK must not invent a value
+	if state.AllowRate != 0.0 {
+		t.Errorf("expected AllowRate=0.0, got %f", state.AllowRate)
+	}
+	if !logger.HasWarn("SSE event has null allow_rate for half_open breaker") {
+		t.Error("expected warning about null allow_rate for half_open breaker")
+	}
+}


### PR DESCRIPTION
## Summary
- `sseBreakerEvent.AllowRate` changed from `float64` to `*float64` so JSON `null` is distinguishable from `0.0`
- When the server sends `"allow_rate": null` for a `half_open` breaker, the SDK now logs a warning — previously this was silent and indistinguishable from a legitimate `0.0`
- The SDK does not invent a default value per the [SDK contract](https://tripswitch.dev/docs/sdk-contract.md) — breaker state is observed, never inferred

## Context
Server-side bug in `v1_state_stream_controller.ex` caused `allow_rate: null` to be broadcast for `half_open` breakers (string/atom mismatch in Elixir). Go's `json.Unmarshal` silently decoded `null` → `0.0`, making half_open indistinguishable from fully open with zero diagnostic signal.

## Test plan
- [x] `TestSSE_NullAllowRate_HalfOpen` — sends `"allow_rate": null` in a half_open SSE event, verifies state is stored with `0.0` and warning is emitted
- [x] Full test suite passes