### PR TITLE
feat: add workspace support to admin package

### DIFF
--- a/admin/admin_integration_test.go
+++ b/admin/admin_integration_test.go
@@ -86,7 +86,7 @@ func TestIntegration_ProjectCRUD(t *testing.T) {
 	})
 
 	// List
-	result, err := client.ListProjects(ctx)
+	result, err := client.ListProjects(ctx, ListProjectsParams{})
 	if err != nil {
 		t.Fatalf("ListProjects failed: %v", err)
 	}

--- a/admin/admin_integration_test.go
+++ b/admin/admin_integration_test.go
@@ -14,10 +14,12 @@ import (
 //
 // Optional:
 //   TRIPSWITCH_BASE_URL=https://api.tripswitch.dev (defaults to production)
+//   TRIPSWITCH_WORKSPACE_ID=ws_... (required for ProjectCRUD test)
 
-func skipIfNoEnv(t *testing.T) (apiKey, projectID, baseURL string) {
+func skipIfNoEnv(t *testing.T) (apiKey, projectID, baseURL, workspaceID string) {
 	apiKey = os.Getenv("TRIPSWITCH_API_KEY")
 	projectID = os.Getenv("TRIPSWITCH_PROJECT_ID")
+	workspaceID = os.Getenv("TRIPSWITCH_WORKSPACE_ID")
 	baseURL = os.Getenv("TRIPSWITCH_BASE_URL")
 
 	if apiKey == "" || projectID == "" {
@@ -28,11 +30,11 @@ func skipIfNoEnv(t *testing.T) (apiKey, projectID, baseURL string) {
 		baseURL = "https://api.tripswitch.dev"
 	}
 
-	return apiKey, projectID, baseURL
+	return apiKey, projectID, baseURL, workspaceID
 }
 
 func TestIntegration_GetProject(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
+	apiKey, projectID, baseURL, _ := skipIfNoEnv(t)
 
 	client := NewClient(
 		WithAPIKey(apiKey),
@@ -55,7 +57,11 @@ func TestIntegration_GetProject(t *testing.T) {
 }
 
 func TestIntegration_ProjectCRUD(t *testing.T) {
-	apiKey, _, baseURL := skipIfNoEnv(t)
+	apiKey, _, baseURL, workspaceID := skipIfNoEnv(t)
+
+	if workspaceID == "" {
+		t.Skip("Skipping: TRIPSWITCH_WORKSPACE_ID must be set for project CRUD tests")
+	}
 
 	client := NewClient(
 		WithAPIKey(apiKey),
@@ -69,7 +75,8 @@ func TestIntegration_ProjectCRUD(t *testing.T) {
 
 	// Create
 	project, err := client.CreateProject(ctx, CreateProjectInput{
-		Name: projectName,
+		WorkspaceID: workspaceID,
+		Name:        projectName,
 	})
 	if err != nil {
 		t.Fatalf("CreateProject failed: %v", err)
@@ -119,7 +126,7 @@ func TestIntegration_ProjectCRUD(t *testing.T) {
 }
 
 func TestIntegration_ListBreakers(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
+	apiKey, projectID, baseURL, _ := skipIfNoEnv(t)
 
 	client := NewClient(
 		WithAPIKey(apiKey),
@@ -144,7 +151,7 @@ func TestIntegration_ListBreakers(t *testing.T) {
 // because it requires a project API key (eb_pk_), not an admin key.
 
 func TestIntegration_BreakerCRUD(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
+	apiKey, projectID, baseURL, _ := skipIfNoEnv(t)
 
 	client := NewClient(
 		WithAPIKey(apiKey),
@@ -210,7 +217,7 @@ func TestIntegration_BreakerCRUD(t *testing.T) {
 }
 
 func TestIntegration_ListRouters(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
+	apiKey, projectID, baseURL, _ := skipIfNoEnv(t)
 
 	client := NewClient(
 		WithAPIKey(apiKey),
@@ -232,7 +239,7 @@ func TestIntegration_ListRouters(t *testing.T) {
 }
 
 func TestIntegration_ListNotificationChannels(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
+	apiKey, projectID, baseURL, _ := skipIfNoEnv(t)
 
 	client := NewClient(
 		WithAPIKey(apiKey),
@@ -254,7 +261,7 @@ func TestIntegration_ListNotificationChannels(t *testing.T) {
 }
 
 func TestIntegration_ListEvents(t *testing.T) {
-	apiKey, projectID, baseURL := skipIfNoEnv(t)
+	apiKey, projectID, baseURL, _ := skipIfNoEnv(t)
 
 	client := NewClient(
 		WithAPIKey(apiKey),

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -644,7 +644,7 @@ func TestListProjects(t *testing.T) {
 
 	client := NewClient(WithBaseURL(server.URL))
 
-	result, err := client.ListProjects(context.Background())
+	result, err := client.ListProjects(context.Background(), ListProjectsParams{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/admin/projects.go
+++ b/admin/projects.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 // ErrDeleteConfirmation is returned when DeleteProject is called without
@@ -12,11 +13,18 @@ import (
 var ErrDeleteConfirmation = errors.New("tripswitch: delete confirmation failed")
 
 // ListProjects retrieves all projects for the authenticated org.
-func (c *Client) ListProjects(ctx context.Context, opts ...RequestOption) (*ListProjectsResponse, error) {
+// Use params.WorkspaceID to filter by workspace.
+func (c *Client) ListProjects(ctx context.Context, params ListProjectsParams, opts ...RequestOption) (*ListProjectsResponse, error) {
+	query := url.Values{}
+	if params.WorkspaceID != "" {
+		query.Set("workspace_id", params.WorkspaceID)
+	}
+
 	var result ListProjectsResponse
 	err := c.do(ctx, request{
 		method:  http.MethodGet,
 		path:    "/v1/projects",
+		query:   query,
 		options: opts,
 	}, &result)
 	if err != nil {

--- a/admin/types.go
+++ b/admin/types.go
@@ -71,6 +71,7 @@ type ListProjectsParams struct {
 // ListProjectsResponse contains the response from listing projects.
 type ListProjectsResponse struct {
 	Projects []Project `json:"projects"`
+	Count    int       `json:"count"`
 }
 
 // DeleteProjectOption configures a DeleteProject call.

--- a/admin/types.go
+++ b/admin/types.go
@@ -42,6 +42,11 @@ type UpdateWorkspaceInput struct {
 	Slug *string `json:"slug,omitempty"`
 }
 
+// ListWorkspacesResponse contains the response from listing workspaces.
+type ListWorkspacesResponse struct {
+	Workspaces []Workspace `json:"workspaces"`
+}
+
 // Project represents a Tripswitch project.
 type Project struct {
 	ID                  string `json:"project_id"`
@@ -60,7 +65,7 @@ type CreateProjectInput struct {
 
 // ListProjectsParams contains parameters for listing projects.
 type ListProjectsParams struct {
-	WorkspaceID string // optional filter
+	WorkspaceID string `json:"workspace_id,omitempty"`
 }
 
 // ListProjectsResponse contains the response from listing projects.

--- a/admin/types.go
+++ b/admin/types.go
@@ -20,9 +20,32 @@ type ListParams struct {
 	Limit  int    `json:"limit,omitempty"`
 }
 
+// Workspace represents a Tripswitch workspace.
+type Workspace struct {
+	ID         string    `json:"id"`
+	Name       string    `json:"name"`
+	Slug       string    `json:"slug"`
+	OrgID      string    `json:"org_id"`
+	InsertedAt time.Time `json:"inserted_at"`
+}
+
+// CreateWorkspaceInput contains fields for creating a workspace.
+type CreateWorkspaceInput struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// UpdateWorkspaceInput contains fields for updating a workspace.
+// Use Ptr() to set optional fields.
+type UpdateWorkspaceInput struct {
+	Name *string `json:"name,omitempty"`
+	Slug *string `json:"slug,omitempty"`
+}
+
 // Project represents a Tripswitch project.
 type Project struct {
 	ID                  string `json:"project_id"`
+	WorkspaceID         string `json:"workspace_id"`
 	Name                string `json:"name"`
 	SlackWebhookURL     string `json:"slack_webhook_url,omitempty"`
 	TraceIDURLTemplate  string `json:"trace_id_url_template,omitempty"`
@@ -31,7 +54,13 @@ type Project struct {
 
 // CreateProjectInput contains fields for creating a project.
 type CreateProjectInput struct {
-	Name string `json:"name"`
+	WorkspaceID string `json:"workspace_id"`
+	Name        string `json:"name"`
+}
+
+// ListProjectsParams contains parameters for listing projects.
+type ListProjectsParams struct {
+	WorkspaceID string // optional filter
 }
 
 // ListProjectsResponse contains the response from listing projects.

--- a/admin/workspaces.go
+++ b/admin/workspaces.go
@@ -1,0 +1,73 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+)
+
+// ListWorkspaces retrieves all workspaces for the authenticated org.
+func (c *Client) ListWorkspaces(ctx context.Context, opts ...RequestOption) ([]Workspace, error) {
+	var result []Workspace
+	err := c.do(ctx, request{
+		method:  http.MethodGet,
+		path:    "/v1/workspaces",
+		options: opts,
+	}, &result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CreateWorkspace creates a new workspace.
+func (c *Client) CreateWorkspace(ctx context.Context, input CreateWorkspaceInput, opts ...RequestOption) (*Workspace, error) {
+	var workspace Workspace
+	err := c.do(ctx, request{
+		method:  http.MethodPost,
+		path:    "/v1/workspaces",
+		body:    input,
+		options: opts,
+	}, &workspace)
+	if err != nil {
+		return nil, err
+	}
+	return &workspace, nil
+}
+
+// GetWorkspace retrieves a workspace by ID.
+func (c *Client) GetWorkspace(ctx context.Context, workspaceID string, opts ...RequestOption) (*Workspace, error) {
+	var workspace Workspace
+	err := c.do(ctx, request{
+		method:  http.MethodGet,
+		path:    "/v1/workspaces/" + workspaceID,
+		options: opts,
+	}, &workspace)
+	if err != nil {
+		return nil, err
+	}
+	return &workspace, nil
+}
+
+// UpdateWorkspace updates a workspace's settings.
+func (c *Client) UpdateWorkspace(ctx context.Context, workspaceID string, input UpdateWorkspaceInput, opts ...RequestOption) (*Workspace, error) {
+	var workspace Workspace
+	err := c.do(ctx, request{
+		method:  http.MethodPatch,
+		path:    "/v1/workspaces/" + workspaceID,
+		body:    input,
+		options: opts,
+	}, &workspace)
+	if err != nil {
+		return nil, err
+	}
+	return &workspace, nil
+}
+
+// DeleteWorkspace deletes a workspace by ID.
+func (c *Client) DeleteWorkspace(ctx context.Context, workspaceID string, opts ...RequestOption) error {
+	return c.do(ctx, request{
+		method:  http.MethodDelete,
+		path:    "/v1/workspaces/" + workspaceID,
+		options: opts,
+	}, nil)
+}

--- a/admin/workspaces.go
+++ b/admin/workspaces.go
@@ -6,8 +6,8 @@ import (
 )
 
 // ListWorkspaces retrieves all workspaces for the authenticated org.
-func (c *Client) ListWorkspaces(ctx context.Context, opts ...RequestOption) ([]Workspace, error) {
-	var result []Workspace
+func (c *Client) ListWorkspaces(ctx context.Context, opts ...RequestOption) (*ListWorkspacesResponse, error) {
+	var result ListWorkspacesResponse
 	err := c.do(ctx, request{
 		method:  http.MethodGet,
 		path:    "/v1/workspaces",
@@ -16,7 +16,7 @@ func (c *Client) ListWorkspaces(ctx context.Context, opts ...RequestOption) ([]W
 	if err != nil {
 		return nil, err
 	}
-	return result, nil
+	return &result, nil
 }
 
 // CreateWorkspace creates a new workspace.

--- a/admin/workspaces_test.go
+++ b/admin/workspaces_test.go
@@ -19,24 +19,26 @@ func TestListWorkspaces(t *testing.T) {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode([]Workspace{
-			{ID: "ws_1", Name: "workspace-one", Slug: "workspace-one", OrgID: "org_1"},
-			{ID: "ws_2", Name: "workspace-two", Slug: "workspace-two", OrgID: "org_1"},
+		json.NewEncoder(w).Encode(ListWorkspacesResponse{
+			Workspaces: []Workspace{
+				{ID: "ws_1", Name: "workspace-one", Slug: "workspace-one", OrgID: "org_1"},
+				{ID: "ws_2", Name: "workspace-two", Slug: "workspace-two", OrgID: "org_1"},
+			},
 		})
 	}))
 	defer server.Close()
 
 	client := NewClient(WithBaseURL(server.URL))
 
-	workspaces, err := client.ListWorkspaces(context.Background())
+	result, err := client.ListWorkspaces(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(workspaces) != 2 {
-		t.Errorf("expected 2 workspaces, got %d", len(workspaces))
+	if len(result.Workspaces) != 2 {
+		t.Errorf("expected 2 workspaces, got %d", len(result.Workspaces))
 	}
-	if workspaces[0].ID != "ws_1" {
-		t.Errorf("expected ID 'ws_1', got %q", workspaces[0].ID)
+	if result.Workspaces[0].ID != "ws_1" {
+		t.Errorf("expected ID 'ws_1', got %q", result.Workspaces[0].ID)
 	}
 }
 

--- a/admin/workspaces_test.go
+++ b/admin/workspaces_test.go
@@ -1,0 +1,170 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestListWorkspaces(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/workspaces" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]Workspace{
+			{ID: "ws_1", Name: "workspace-one", Slug: "workspace-one", OrgID: "org_1"},
+			{ID: "ws_2", Name: "workspace-two", Slug: "workspace-two", OrgID: "org_1"},
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	workspaces, err := client.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(workspaces) != 2 {
+		t.Errorf("expected 2 workspaces, got %d", len(workspaces))
+	}
+	if workspaces[0].ID != "ws_1" {
+		t.Errorf("expected ID 'ws_1', got %q", workspaces[0].ID)
+	}
+}
+
+func TestCreateWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/workspaces" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var input CreateWorkspaceInput
+		json.NewDecoder(r.Body).Decode(&input)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(Workspace{
+			ID:         "ws_new",
+			Name:       input.Name,
+			Slug:       input.Slug,
+			OrgID:      "org_1",
+			InsertedAt: time.Now(),
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	workspace, err := client.CreateWorkspace(context.Background(), CreateWorkspaceInput{
+		Name: "my-workspace",
+		Slug: "my-workspace",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if workspace.Name != "my-workspace" {
+		t.Errorf("expected name 'my-workspace', got %q", workspace.Name)
+	}
+	if workspace.Slug != "my-workspace" {
+		t.Errorf("expected slug 'my-workspace', got %q", workspace.Slug)
+	}
+}
+
+func TestGetWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/workspaces/ws_123" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Workspace{
+			ID:    "ws_123",
+			Name:  "Test Workspace",
+			Slug:  "test-workspace",
+			OrgID: "org_1",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	workspace, err := client.GetWorkspace(context.Background(), "ws_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if workspace.ID != "ws_123" {
+		t.Errorf("expected ID 'ws_123', got %q", workspace.ID)
+	}
+	if workspace.Name != "Test Workspace" {
+		t.Errorf("expected Name 'Test Workspace', got %q", workspace.Name)
+	}
+}
+
+func TestUpdateWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/workspaces/ws_123" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+
+		var input UpdateWorkspaceInput
+		json.NewDecoder(r.Body).Decode(&input)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Workspace{
+			ID:    "ws_123",
+			Name:  *input.Name,
+			Slug:  "test-workspace",
+			OrgID: "org_1",
+		})
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	workspace, err := client.UpdateWorkspace(context.Background(), "ws_123", UpdateWorkspaceInput{
+		Name: Ptr("Updated Workspace"),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if workspace.Name != "Updated Workspace" {
+		t.Errorf("expected Name 'Updated Workspace', got %q", workspace.Name)
+	}
+}
+
+func TestDeleteWorkspace(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if r.URL.Path != "/v1/workspaces/ws_123" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(WithBaseURL(server.URL))
+
+	err := client.DeleteWorkspace(context.Background(), "ws_123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Workspace`, `CreateWorkspaceInput`, `UpdateWorkspaceInput` types and full CRUD (`ListWorkspaces`, `CreateWorkspace`, `GetWorkspace`, `UpdateWorkspace`, `DeleteWorkspace`)
- Add `WorkspaceID` field to `Project` and `CreateProjectInput`
- Update `ListProjects` to accept `ListProjectsParams` with optional `WorkspaceID` filter

## Breaking changes
- `ListProjects` signature changed: now requires a `ListProjectsParams` argument (pass `ListProjectsParams{}` for previous behavior)
- `CreateProjectInput` has a new `WorkspaceID` field (required by the API)

## Test plan
- [x] Unit tests for all 5 workspace CRUD methods (`admin/workspaces_test.go`)
- [x] Updated existing `ListProjects` test calls for new signature
- [x] `go build ./...` passes
- [x] `go test ./admin/...` passes
- [x] `go vet ./...` passes

Closes #74