### PR TITLE
fix: update admin Breaker.RouterID to RouterIDs []string

### DIFF
--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -145,6 +145,9 @@ func TestCreateBreaker(t *testing.T) {
 	if breaker.ID != "breaker_456" {
 		t.Errorf("expected ID 'breaker_456', got %q", breaker.ID)
 	}
+	if len(breaker.RouterIDs) != 1 || breaker.RouterIDs[0] != "router_789" {
+		t.Errorf("expected RouterIDs [router_789], got %v", breaker.RouterIDs)
+	}
 }
 
 func TestListBreakers(t *testing.T) {

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -125,7 +125,7 @@ func TestCreateBreaker(t *testing.T) {
 				Name: input.Name,
 				Kind: input.Kind,
 			},
-			"router_id": "router_789",
+			"router_ids": []string{"router_789"},
 		})
 	}))
 	defer server.Close()
@@ -800,7 +800,7 @@ func TestCreateBreakerWithMetadata(t *testing.T) {
 				Kind:     input.Kind,
 				Metadata: input.Metadata,
 			},
-			"router_id": "router_789",
+			"router_ids": []string{"router_789"},
 		})
 	}))
 	defer server.Close()
@@ -883,7 +883,7 @@ func TestUpdateBreakerWithMetadata(t *testing.T) {
 				Name:     "api-latency",
 				Metadata: input.Metadata,
 			},
-			"router_id": "router_789",
+			"router_ids": []string{"router_789"},
 		})
 	}))
 	defer server.Close()
@@ -918,7 +918,7 @@ func TestCreateBreakerWithNilMetadata(t *testing.T) {
 				ID:   "breaker_456",
 				Name: "api-latency",
 			},
-			"router_id": "router_789",
+			"router_ids": []string{"router_789"},
 		})
 	}))
 	defer server.Close()

--- a/admin/breakers.go
+++ b/admin/breakers.go
@@ -32,8 +32,8 @@ func (c *Client) ListBreakers(ctx context.Context, projectID string, params List
 
 // breakerResponse wraps single breaker responses from the API.
 type breakerResponse struct {
-	Breaker  Breaker `json:"breaker"`
-	RouterID string  `json:"router_id,omitempty"`
+	Breaker   Breaker  `json:"breaker"`
+	RouterIDs []string `json:"router_ids,omitempty"`
 }
 
 // CreateBreaker creates a new breaker.
@@ -48,8 +48,8 @@ func (c *Client) CreateBreaker(ctx context.Context, projectID string, input Crea
 	if err != nil {
 		return nil, err
 	}
-	// Copy router_id from wrapper to breaker
-	resp.Breaker.RouterID = resp.RouterID
+	// Copy router_ids from wrapper to breaker
+	resp.Breaker.RouterIDs = resp.RouterIDs
 	return &resp.Breaker, nil
 }
 
@@ -79,8 +79,8 @@ func (c *Client) GetBreaker(ctx context.Context, projectID, breakerID string, op
 	if err != nil {
 		return nil, err
 	}
-	// Copy router_id from wrapper to breaker
-	resp.Breaker.RouterID = resp.RouterID
+	// Copy router_ids from wrapper to breaker
+	resp.Breaker.RouterIDs = resp.RouterIDs
 	return &resp.Breaker, nil
 }
 
@@ -96,8 +96,8 @@ func (c *Client) UpdateBreaker(ctx context.Context, projectID, breakerID string,
 	if err != nil {
 		return nil, err
 	}
-	// Copy router_id from wrapper to breaker
-	resp.Breaker.RouterID = resp.RouterID
+	// Copy router_ids from wrapper to breaker
+	resp.Breaker.RouterIDs = resp.RouterIDs
 	return &resp.Breaker, nil
 }
 

--- a/admin/types.go
+++ b/admin/types.go
@@ -49,12 +49,12 @@ type ListWorkspacesResponse struct {
 
 // Project represents a Tripswitch project.
 type Project struct {
-	ID                  string `json:"project_id"`
-	WorkspaceID         string `json:"workspace_id"`
-	Name                string `json:"name"`
-	SlackWebhookURL     string `json:"slack_webhook_url,omitempty"`
-	TraceIDURLTemplate  string `json:"trace_id_url_template,omitempty"`
-	EnableSignedIngest  bool   `json:"enable_signed_ingest"`
+	ID                 string `json:"project_id"`
+	WorkspaceID        string `json:"workspace_id"`
+	Name               string `json:"name"`
+	SlackWebhookURL    string `json:"slack_webhook_url,omitempty"`
+	TraceIDURLTemplate string `json:"trace_id_url_template,omitempty"`
+	EnableSignedIngest bool   `json:"enable_signed_ingest"`
 }
 
 // CreateProjectInput contains fields for creating a project.
@@ -152,7 +152,7 @@ const (
 // Breaker represents a circuit breaker configuration.
 type Breaker struct {
 	ID                          string            `json:"id"`
-	RouterID                    string            `json:"router_id,omitempty"`
+	RouterIDs                   []string          `json:"router_ids,omitempty"`
 	Name                        string            `json:"name"`
 	Metric                      string            `json:"metric"`
 	Kind                        BreakerKind       `json:"kind"`
@@ -162,16 +162,16 @@ type Breaker struct {
 	WindowMs                    int               `json:"window_ms,omitempty"`
 	MinCount                    int               `json:"min_count,omitempty"`
 	MinStateDurationMs          int               `json:"min_state_duration_ms,omitempty"`
-	CooldownMs                      int               `json:"cooldown_ms,omitempty"`
-	EvalIntervalMs                  int               `json:"eval_interval_ms,omitempty"`
-	HalfOpenConfirmationMs          int               `json:"half_open_confirmation_ms,omitempty"`
-	HalfOpenBackoffEnabled          bool              `json:"half_open_backoff_enabled,omitempty"`
-	HalfOpenBackoffCapMs            int               `json:"half_open_backoff_cap_ms,omitempty"`
-	HalfOpenIndeterminatePolicy     HalfOpenPolicy    `json:"half_open_indeterminate_policy,omitempty"`
-	RecoveryWindowMs                int               `json:"recovery_window_ms,omitempty"`
-	RecoveryAllowRateRampSteps      int               `json:"recovery_allow_rate_ramp_steps,omitempty"`
-	Actions                         map[string]any    `json:"actions,omitempty"`
-	Metadata                        map[string]string `json:"metadata,omitempty"`
+	CooldownMs                  int               `json:"cooldown_ms,omitempty"`
+	EvalIntervalMs              int               `json:"eval_interval_ms,omitempty"`
+	HalfOpenConfirmationMs      int               `json:"half_open_confirmation_ms,omitempty"`
+	HalfOpenBackoffEnabled      bool              `json:"half_open_backoff_enabled,omitempty"`
+	HalfOpenBackoffCapMs        int               `json:"half_open_backoff_cap_ms,omitempty"`
+	HalfOpenIndeterminatePolicy HalfOpenPolicy    `json:"half_open_indeterminate_policy,omitempty"`
+	RecoveryWindowMs            int               `json:"recovery_window_ms,omitempty"`
+	RecoveryAllowRateRampSteps  int               `json:"recovery_allow_rate_ramp_steps,omitempty"`
+	Actions                     map[string]any    `json:"actions,omitempty"`
+	Metadata                    map[string]string `json:"metadata,omitempty"`
 }
 
 // CreateBreakerInput contains fields for creating a breaker.
@@ -185,14 +185,14 @@ type CreateBreakerInput struct {
 	WindowMs                    int               `json:"window_ms,omitempty"`
 	MinCount                    int               `json:"min_count,omitempty"`
 	MinStateDurationMs          int               `json:"min_state_duration_ms,omitempty"`
-	CooldownMs                      int               `json:"cooldown_ms,omitempty"`
-	EvalIntervalMs                  int               `json:"eval_interval_ms,omitempty"`
-	HalfOpenBackoffEnabled          bool              `json:"half_open_backoff_enabled,omitempty"`
-	HalfOpenBackoffCapMs            int               `json:"half_open_backoff_cap_ms,omitempty"`
-	HalfOpenIndeterminatePolicy     HalfOpenPolicy    `json:"half_open_indeterminate_policy,omitempty"`
-	RecoveryAllowRateRampSteps      int               `json:"recovery_allow_rate_ramp_steps,omitempty"`
-	Actions                         map[string]any    `json:"actions,omitempty"`
-	Metadata                        map[string]string `json:"metadata,omitempty"`
+	CooldownMs                  int               `json:"cooldown_ms,omitempty"`
+	EvalIntervalMs              int               `json:"eval_interval_ms,omitempty"`
+	HalfOpenBackoffEnabled      bool              `json:"half_open_backoff_enabled,omitempty"`
+	HalfOpenBackoffCapMs        int               `json:"half_open_backoff_cap_ms,omitempty"`
+	HalfOpenIndeterminatePolicy HalfOpenPolicy    `json:"half_open_indeterminate_policy,omitempty"`
+	RecoveryAllowRateRampSteps  int               `json:"recovery_allow_rate_ramp_steps,omitempty"`
+	Actions                     map[string]any    `json:"actions,omitempty"`
+	Metadata                    map[string]string `json:"metadata,omitempty"`
 }
 
 // UpdateBreakerInput contains fields for updating a breaker.
@@ -207,14 +207,14 @@ type UpdateBreakerInput struct {
 	WindowMs                    *int              `json:"window_ms,omitempty"`
 	MinCount                    *int              `json:"min_count,omitempty"`
 	MinStateDurationMs          *int              `json:"min_state_duration_ms,omitempty"`
-	CooldownMs                      *int              `json:"cooldown_ms,omitempty"`
-	EvalIntervalMs                  *int              `json:"eval_interval_ms,omitempty"`
-	HalfOpenBackoffEnabled          *bool             `json:"half_open_backoff_enabled,omitempty"`
-	HalfOpenBackoffCapMs            *int              `json:"half_open_backoff_cap_ms,omitempty"`
-	HalfOpenIndeterminatePolicy     *HalfOpenPolicy   `json:"half_open_indeterminate_policy,omitempty"`
-	RecoveryAllowRateRampSteps      *int              `json:"recovery_allow_rate_ramp_steps,omitempty"`
-	Actions                         map[string]any    `json:"actions,omitempty"`
-	Metadata                        map[string]string `json:"metadata,omitempty"`
+	CooldownMs                  *int              `json:"cooldown_ms,omitempty"`
+	EvalIntervalMs              *int              `json:"eval_interval_ms,omitempty"`
+	HalfOpenBackoffEnabled      *bool             `json:"half_open_backoff_enabled,omitempty"`
+	HalfOpenBackoffCapMs        *int              `json:"half_open_backoff_cap_ms,omitempty"`
+	HalfOpenIndeterminatePolicy *HalfOpenPolicy   `json:"half_open_indeterminate_policy,omitempty"`
+	RecoveryAllowRateRampSteps  *int              `json:"recovery_allow_rate_ramp_steps,omitempty"`
+	Actions                     map[string]any    `json:"actions,omitempty"`
+	Metadata                    map[string]string `json:"metadata,omitempty"`
 }
 
 // SyncBreakersInput contains a list of breakers for bulk sync.
@@ -224,9 +224,9 @@ type SyncBreakersInput struct {
 
 // BreakerState represents the current state of a circuit breaker.
 type BreakerState struct {
-	BreakerID string  `json:"breaker_id"`
-	State     string  `json:"state"` // "open", "closed", "half_open"
-	AllowRate float64 `json:"allow_rate"`
+	BreakerID string    `json:"breaker_id"`
+	State     string    `json:"state"` // "open", "closed", "half_open"
+	AllowRate float64   `json:"allow_rate"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
@@ -255,14 +255,14 @@ const (
 
 // Router represents a router configuration.
 type Router struct {
-	ID           string     `json:"id"`
-	Name         string     `json:"name"`
-	Mode         RouterMode `json:"mode"`
-	Enabled      bool       `json:"enabled"`
-	BreakerCount int        `json:"breaker_count,omitempty"`
-	Breakers     []Breaker  `json:"breakers,omitempty"`
-	InsertedAt   time.Time  `json:"inserted_at,omitempty"`
-	CreatedBy    string     `json:"created_by,omitempty"`
+	ID           string            `json:"id"`
+	Name         string            `json:"name"`
+	Mode         RouterMode        `json:"mode"`
+	Enabled      bool              `json:"enabled"`
+	BreakerCount int               `json:"breaker_count,omitempty"`
+	Breakers     []Breaker         `json:"breakers,omitempty"`
+	InsertedAt   time.Time         `json:"inserted_at,omitempty"`
+	CreatedBy    string            `json:"created_by,omitempty"`
 	Metadata     map[string]string `json:"metadata,omitempty"`
 }
 
@@ -273,20 +273,20 @@ type ListRoutersResponse struct {
 
 // CreateRouterInput contains fields for creating a router.
 type CreateRouterInput struct {
-	Name        string     `json:"name"`
-	Description string     `json:"description,omitempty"`
-	Mode        RouterMode `json:"mode"`
-	Enabled     bool       `json:"enabled,omitempty"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Mode        RouterMode        `json:"mode"`
+	Enabled     bool              `json:"enabled,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
 // UpdateRouterInput contains fields for updating a router.
 // Use Ptr() to set optional fields.
 type UpdateRouterInput struct {
-	Name        *string     `json:"name,omitempty"`
-	Description *string     `json:"description,omitempty"`
-	Mode        *RouterMode `json:"mode,omitempty"`
-	Enabled     *bool       `json:"enabled,omitempty"`
+	Name        *string           `json:"name,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Mode        *RouterMode       `json:"mode,omitempty"`
+	Enabled     *bool             `json:"enabled,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
 }
 
@@ -338,10 +338,10 @@ type CreateNotificationChannelInput struct {
 // UpdateNotificationChannelInput contains fields for updating a notification channel.
 // Use Ptr() to set optional fields.
 type UpdateNotificationChannelInput struct {
-	Name    *string                  `json:"name,omitempty"`
-	Config  map[string]any           `json:"config,omitempty"`
-	Events  []NotificationEventType  `json:"events,omitempty"`
-	Enabled *bool                    `json:"enabled,omitempty"`
+	Name    *string                 `json:"name,omitempty"`
+	Config  map[string]any          `json:"config,omitempty"`
+	Events  []NotificationEventType `json:"events,omitempty"`
+	Enabled *bool                   `json:"enabled,omitempty"`
 }
 
 // Event represents a breaker state transition event.


### PR DESCRIPTION
## Summary
- Updates `admin.Breaker.RouterID` (string) to `RouterIDs` ([]string) to match the API's breaking change from `router_id` to `router_ids`
- Updates the `breakerResponse` wrapper and copy logic in `CreateBreaker`, `GetBreaker`, `UpdateBreaker`
- Updates test fixtures to use the new array format

## Test plan
- [x] `go vet ./...` passes
- [x] `gofmt` clean
- [x] `go test ./admin/` passes