### PR TITLE
fix: shutdown flush drops all samples due to cancelled context

### DIFF
--- a/tripswitch.go
+++ b/tripswitch.go
@@ -165,7 +165,7 @@ type Client struct {
 	reportChan     chan reportEntry
 	droppedSamples uint64 // atomic counter for dropped samples
 	httpClient     *http.Client
-	closeCtx       context.Context // set in Close() before cancelling c.ctx; used by shutdown flush
+	closeCtxCh     chan context.Context // receives Close()'s ctx once; read by flusher for shutdown flush
 
 	// metadata cache
 	metaMu           sync.RWMutex
@@ -199,6 +199,7 @@ func NewClient(ctx context.Context, projectID string, opts ...Option) (*Client, 
 		breakerStates: make(map[string]breakerState),
 		sseReady:      make(chan struct{}),
 		reportChan:    make(chan reportEntry, 10000),
+		closeCtxCh:   make(chan context.Context, 1),
 		httpClient:    &http.Client{Timeout: 30 * time.Second},
 		metaSyncInterval: 30 * time.Second,
 	}
@@ -749,9 +750,10 @@ func (c *Client) Report(input ReportInput) {
 func (c *Client) Close(ctx context.Context) error {
 	var err error
 	c.closeOnce.Do(func() {
-		// Store the caller's context before cancelling c.ctx so the shutdown
-		// flush can make HTTP requests within the caller's deadline.
-		c.closeCtx = ctx
+		// Deliver the caller's context to the flusher before cancelling c.ctx.
+		// The channel send synchronizes-before the Done() receive in startFlusher,
+		// so there is no data race on the context value.
+		c.closeCtxCh <- ctx
 		// Signal all goroutines to stop
 		c.cancel()
 
@@ -1118,7 +1120,11 @@ func (c *Client) startFlusher() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			flush(c.closeCtx) // Final drain uses Close()'s context so HTTP can complete
+			// Receive the context delivered by Close() before cancel() was called.
+			// The buffered send in Close() always precedes the cancel(), so this
+			// receive is guaranteed to succeed without blocking.
+			shutdownCtx := <-c.closeCtxCh
+			flush(shutdownCtx)
 			return
 		case entry := <-c.reportChan:
 			batch = append(batch, entry)

--- a/tripswitch.go
+++ b/tripswitch.go
@@ -165,6 +165,7 @@ type Client struct {
 	reportChan     chan reportEntry
 	droppedSamples uint64 // atomic counter for dropped samples
 	httpClient     *http.Client
+	closeCtx       context.Context // set in Close() before cancelling c.ctx; used by shutdown flush
 
 	// metadata cache
 	metaMu           sync.RWMutex
@@ -748,6 +749,9 @@ func (c *Client) Report(input ReportInput) {
 func (c *Client) Close(ctx context.Context) error {
 	var err error
 	c.closeOnce.Do(func() {
+		// Store the caller's context before cancelling c.ctx so the shutdown
+		// flush can make HTTP requests within the caller's deadline.
+		c.closeCtx = ctx
 		// Signal all goroutines to stop
 		c.cancel()
 
@@ -1097,7 +1101,7 @@ func (c *Client) startFlusher() {
 	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 
-	flush := func() {
+	flush := func(ctx context.Context) {
 		if len(batch) == 0 {
 			return
 		}
@@ -1105,7 +1109,7 @@ func (c *Client) startFlusher() {
 		c.wg.Add(1)
 		go func(b []reportEntry) {
 			defer c.wg.Done()
-			c.sendBatch(b)
+			c.sendBatch(ctx, b)
 		}(batch)
 		batch = make([]reportEntry, 0, 500)
 		ticker.Reset(15 * time.Second)
@@ -1114,21 +1118,21 @@ func (c *Client) startFlusher() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			flush() // Final drain on shutdown
+			flush(c.closeCtx) // Final drain uses Close()'s context so HTTP can complete
 			return
 		case entry := <-c.reportChan:
 			batch = append(batch, entry)
 			if len(batch) >= 500 {
-				flush()
+				flush(c.ctx)
 			}
 		case <-ticker.C:
-			flush()
+			flush(c.ctx)
 		}
 	}
 }
 
 // sendBatch sends a batch of samples to the metrics ingest endpoint.
-func (c *Client) sendBatch(batch []reportEntry) {
+func (c *Client) sendBatch(ctx context.Context, batch []reportEntry) {
 	if len(batch) == 0 {
 		return
 	}
@@ -1186,8 +1190,7 @@ func (c *Client) sendBatch(batch []reportEntry) {
 	url := c.baseURL + "/v1/projects/" + c.projectID + "/ingest"
 
 	for attempt := 0; attempt <= len(backoffs); attempt++ {
-		// Don't retry if context is cancelled (shutdown in progress)
-		if c.ctx.Err() != nil {
+		if ctx.Err() != nil {
 			c.logger.Debug("batch send cancelled due to shutdown", "remaining", len(batch))
 			atomic.AddUint64(&c.droppedSamples, uint64(len(batch)))
 			return
@@ -1196,14 +1199,14 @@ func (c *Client) sendBatch(batch []reportEntry) {
 		if attempt > 0 {
 			select {
 			case <-time.After(backoffs[attempt-1]):
-			case <-c.ctx.Done():
+			case <-ctx.Done():
 				c.logger.Debug("batch send cancelled during backoff", "remaining", len(batch))
 				atomic.AddUint64(&c.droppedSamples, uint64(len(batch)))
 				return
 			}
 		}
 
-		req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, url, bytes.NewReader(wireBytes))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wireBytes))
 		if err != nil {
 			c.logger.Error("failed to create request", "error", err)
 			continue
@@ -1220,7 +1223,7 @@ func (c *Client) sendBatch(batch []reportEntry) {
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			// Don't log error if context was cancelled
-			if c.ctx.Err() == nil {
+			if ctx.Err() == nil {
 				c.logger.Error("failed to send batch", "error", err, "attempt", attempt+1)
 			}
 			continue

--- a/tripswitch_test.go
+++ b/tripswitch_test.go
@@ -194,6 +194,70 @@ func TestClose(t *testing.T) {
 	}
 }
 
+// TestClose_FlushesBufferedSamples verifies that samples buffered in the flusher's
+// batch are delivered when Close() is called, even though c.ctx is cancelled at that
+// point. Previously, sendBatch checked c.ctx.Err() and dropped immediately on shutdown.
+func TestClose_FlushesBufferedSamples(t *testing.T) {
+	var ingestCalls int32
+	ingestReceived := make(chan struct{}, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/projects/proj_test/ingest" {
+			atomic.AddInt32(&ingestCalls, 1)
+			select {
+			case ingestReceived <- struct{}{}:
+			default:
+			}
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(context.Background(), "proj_test",
+		WithBaseURL(server.URL),
+		WithIngestSecret("aabbccddee11223344556677889900aabbccddeeff11223344556677889900aa"),
+		withSSEDisabled(),
+		withMetadataSyncDisabled(),
+	)
+	if err != nil {
+		t.Fatalf("NewClient() returned error: %v", err)
+	}
+
+	client.breakerStatesMu.Lock()
+	client.breakerStates["test-breaker"] = breakerState{State: "closed", AllowRate: 1.0}
+	client.breakerStatesMu.Unlock()
+
+	_, _ = Execute(client, context.Background(), func() (int, error) {
+		return 1, nil
+	}, WithBreakers("test-breaker"), WithRouter("router-1"), WithMetrics(map[string]any{"latency": Latency}))
+
+	// Wait for the flusher goroutine to drain reportChan into its batch.
+	// The flusher is in a tight select loop so 50ms is conservative.
+	time.Sleep(50 * time.Millisecond)
+
+	closeCtx, closeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer closeCancel()
+	if err := client.Close(closeCtx); err != nil {
+		t.Fatalf("Close() returned error: %v", err)
+	}
+
+	select {
+	case <-ingestReceived:
+	default:
+		t.Fatal("ingest endpoint was not called during shutdown flush: samples were dropped instead of sent")
+	}
+
+	if n := atomic.LoadInt32(&ingestCalls); n != 1 {
+		t.Errorf("expected 1 ingest call, got %d", n)
+	}
+
+	if dropped := atomic.LoadUint64(&client.droppedSamples); dropped != 0 {
+		t.Errorf("expected 0 dropped samples, got %d", dropped)
+	}
+}
+
 func TestStats(t *testing.T) {
 	// Start a mock SSE server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -826,7 +890,7 @@ func TestSendBatch_PayloadFormat(t *testing.T) {
 		},
 	}
 
-	client.sendBatch(batch)
+	client.sendBatch(context.Background(), batch)
 
 	// Verify path and headers
 	if receivedPath != "/v1/projects/proj_test/ingest" {
@@ -1933,7 +1997,7 @@ func TestStats_FlushFailures(t *testing.T) {
 		},
 	}
 
-	client.sendBatch(batch)
+	client.sendBatch(context.Background(), batch)
 
 	stats := client.Stats()
 	if stats.FlushFailures != 1 {


### PR DESCRIPTION
## Summary

**Bug:** Calling `Close()` always silently dropped every buffered sample, even with a generous timeout.

**Root cause:** `Close()` calls `c.cancel()` first, which cancels `c.ctx`. By the time the shutdown flush's `sendBatch` goroutine runs, `c.ctx.Err() != nil` — so the top-of-loop guard exits immediately and drops the entire batch without making a network request. The HTTP request was also built with `c.ctx`, so removing the guard alone wouldn't have helped.

**Fix (commit 1):** Thread the caller's `Close(ctx)` context through `sendBatch` as a parameter. `startFlusher` passes `c.ctx` for normal periodic/threshold flushes and the `Close` context only for the final shutdown drain, so the HTTP request can complete within the caller's shutdown budget.

**Fix (commit 2):** The initial implementation stored the close context in a plain struct field written just before `c.cancel()`. Even though sequential ordering makes the write happen-before the flusher reads it (via the context's internal channel close), the race detector may not track happens-before through the context package's internal channel. Replaced the field with a buffered channel (size 1): `Close()` sends into it before calling `cancel()`, and `startFlusher` receives from it after `c.ctx.Done()` fires. The channel send/receive is an unambiguous synchronization point — race-free by construction, and the nil-context panic risk is eliminated entirely.

## Test plan

- [x] `TestClose_FlushesBufferedSamples` — new regression test: buffers a sample, waits for the flusher to drain `reportChan` into its batch, calls `Close()` with a 5s timeout, asserts the ingest endpoint was called and `droppedSamples == 0`
- [x] `go test -race ./...` passes